### PR TITLE
feat: Add religious symbols

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1050,6 +1050,6 @@ _rp	₎
 \nvDash	⊭	
 \swastika	卐	
 \revSwastika	卍	
-\latinCross	✝	
-\starAndCrescent	☪	
-\starOfDavid	✡	
+\latinCross	✝︎	
+\starAndCrescent	☪︎	
+\starOfDavid	✡︎	

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1050,3 +1050,6 @@ _rp	₎
 \nvDash	⊭	
 \swastika	卐	
 \revSwastika	卍	
+\latinCross	✝	
+\starAndCrescent	☪	
+\starOfDavid	✡	


### PR DESCRIPTION
Add three religious symbols: \latinCross ✝︎, \starAndCrescent ☪︎, and \starOfDavid ✡︎. I think it's a *very* bad look for the only religious symbols in this entire dictionary to be the swastikas from #87, regardless of how innocently it is intended.

Potentially some other religious symbols could be added ([this Wikipedia list](https://en.wikipedia.org/wiki/Religious_and_political_symbols_in_Unicode) is a good place to look). But ultimately I'm not familiar enough with enough religions to say which symbols are important, so I just left it at these three for this PR.